### PR TITLE
fix url rendering of singe decimal coverage

### DIFF
--- a/coverbadge/coverbadge.go
+++ b/coverbadge/coverbadge.go
@@ -20,7 +20,7 @@ func (badge Badge) generateBadgeBadgeURL(coverageFloat float64) string {
 	if badge.CoveragePrefix != "" {
 		badge.CoveragePrefix += "%20"
 	}
-	urlTemplate := "https://img.shields.io/badge/%sCoverage-%2.f%%25-brightgreen%s?longCache=true&style=%s"
+	urlTemplate := "https://img.shields.io/badge/%sCoverage-%.f%%25-brightgreen%s?longCache=true&style=%s"
 	return fmt.Sprintf(urlTemplate, badge.CoveragePrefix, coverageFloat, badge.ImageExtension, badge.Style)
 }
 

--- a/coverbadge/coverbadge_test.go
+++ b/coverbadge/coverbadge_test.go
@@ -15,3 +15,18 @@ func TestDownloadBadge(t *testing.T) {
 func TestWriteBadgeToMd(t *testing.T) {
 	coverageBadge.WriteBadgeToMd("coverage_test.md", 22)
 }
+func TestGenerateBadgeBadgeURL_1(t *testing.T) {
+	testUrl(t, 1.1, "https://img.shields.io/badge/Go%20Coverage-1%25-brightgreen.png?longCache=true&style=flat")
+}
+func TestGenerateBadgeBadgeURL_10(t *testing.T) {
+	testUrl(t, 10.1, "https://img.shields.io/badge/Go%20Coverage-10%25-brightgreen.png?longCache=true&style=flat")
+}
+func TestGenerateBadgeBadgeURL_100(t *testing.T) {
+	testUrl(t, 100.1, "https://img.shields.io/badge/Go%20Coverage-100%25-brightgreen.png?longCache=true&style=flat")
+}
+func testUrl(t *testing.T, coverageFloat float64, expected string) {
+	url := coverageBadge.generateBadgeBadgeURL(coverageFloat)
+	if url != expected {
+		t.Fatal("url should be", expected, "but is", url)
+	}
+}


### PR DESCRIPTION
If coverage is in a single decimal range the current implementation renders a space in the url, which leads to an invalid image link.

This pull request changes the number format to generate a valid url.