### PR TITLE
fix multiple Wait() calls

### DIFF
--- a/main.go
+++ b/main.go
@@ -49,9 +49,11 @@ func getCommandOutput(commandString string) chan float64 {
 				fmt.Println(lineText)
 			}
 		}
-		cmd.Wait()
+		if err = cmd.Wait(); nil != err {
+			log.Fatalf("Error running program: %s, %s", cmd.Path, err)
+		}
 	}(reader)
-	if err := cmd.Run(); nil != err {
+	if err := cmd.Start(); nil != err {
 		log.Fatalf("Error running program: %s, %s", cmd.Path, err)
 	}
 	return coverageFloatChannel


### PR DESCRIPTION
## Issue
Running the coverage tool hangs on an uncaught error.

Catch the error on `main.go#52` and it outputs `2020/12/15 23:16:31 Error running program: /usr/local/bin/bash, exec: Wait was already called`.