### PR TITLE
Added option to silence output

### DIFF
--- a/coverbadge/coverbadge.go
+++ b/coverbadge/coverbadge.go
@@ -51,7 +51,7 @@ func (badge Badge) DownloadBadge(filepath string, coverageFloat float64) {
 	return
 }
 
-func (badge Badge) WriteBadgeToMd(filepath string, coverageFloat float64) {
+func (badge Badge) WriteBadgeToMd(filepath string, coverageFloat float64, isSilent bool) {
 	badge.ImageExtension = ".svg"
 	badgeURL := badge.generateBadgeBadgeURL(coverageFloat)
 	newImageTag := fmt.Sprintf("<a href='https://github.com/jpoles1/gopherbadger' target='_blank'>![gopherbadger-tag-do-not-edit](%s)</a>", badgeURL)
@@ -75,5 +75,7 @@ func (badge Badge) WriteBadgeToMd(filepath string, coverageFloat float64) {
 		logging.Fatal("Error: could not write badge url to markdown file: ", err)
 		return
 	}
-	logging.Success("Wrote badge image to markdown file: " + filepath)
+	if !isSilent {
+		logging.Success("Wrote badge image to markdown file: " + filepath)
+	}
 }

--- a/coverbadge/coverbadge_test.go
+++ b/coverbadge/coverbadge_test.go
@@ -3,6 +3,7 @@ package coverbadge
 import (
 	"testing"
 )
+
 var coverageBadge = Badge{
 	CoveragePrefix: "Go",
 	Style:          "flat",
@@ -13,7 +14,7 @@ func TestDownloadBadge(t *testing.T) {
 	coverageBadge.DownloadBadge("test_badge.png", 66)
 }
 func TestWriteBadgeToMd(t *testing.T) {
-	coverageBadge.WriteBadgeToMd("coverage_test.md", 22)
+	coverageBadge.WriteBadgeToMd("coverage_test.md", 22, false)
 }
 func TestGenerateBadgeBadgeURL_1(t *testing.T) {
 	testUrl(t, 1.1, "https://img.shields.io/badge/Go%20Coverage-1%25-brightgreen.png?longCache=true&style=flat")

--- a/main_test.go
+++ b/main_test.go
@@ -5,8 +5,8 @@ import (
 )
 
 func TestGetCommandOutput(t *testing.T) {
-	getCommandOutput("echo test")
-	getCommandOutput("echo 'testline\ncoverage: 35%'")
+	getCommandOutput("echo test", false)
+	getCommandOutput("echo 'testline\ncoverage: 35%'", false)
 }
 
 func TestBadger(t *testing.T) {


### PR DESCRIPTION
Thanks for this great tool! :) I needed a way to not have any output by script, therefore I added the flag `-silent` to not output anything if no errors are encountered.

A lot of Linux cli tools act that way, if everything was successful, no output is shown and the exit code is 0.